### PR TITLE
chore: update LICENSE copyright and add README License section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2020-2021 ApiGear UG (haftungsbeschränkt)
-Copyright (c) 2021-2023 Epic Games Inc. All rights reserved.
+Copyright (c) 2020-2022 ApiGear UG (haftungsbeschränkt)
+Copyright (c) 2022-2026 Epic Games, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Targets:
   master     generates the golden master.
 ```
 
+
+## License
+
+Licensed under the [MIT License](./LICENSE). See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
Updates the LICENSE to the standard, entity-accurate copyright attribution (drops the contradictory "All rights reserved." trailer and corrects the year range) and adds a README License section where missing. MIT is the standard license used across ApiGear projects.